### PR TITLE
1 json file support

### DIFF
--- a/vcflow/src/App.js
+++ b/vcflow/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import SignMessage from './SignMessage';
 import VerifyMessage from './VerifyMessage';
+import GenerateProof from './GenerateProof';
 //import GenerateVerifiableCred from './GenerateVerifiableCred';
 
 //Roadmap
@@ -11,9 +12,9 @@ function LandingPage({ onOptionSelect }) {
   return (
     <div className="container mx-auto h-screen flex justify-center items-center">
       <div className="flex flex-col items-center">
-        <button onClick={() => onOptionSelect('issue')} className="py-2 px-4 bg-green-500 text-white rounded-lg mb-2">Issue</button>
-        <button onClick={() => onOptionSelect('generateProof')} className="py-2 px-4 bg-green-500 text-white rounded-lg mb-2">Generate Proof</button>
-        <button onClick={() => onOptionSelect('verify')} className="py-2 px-4 bg-green-500 text-white rounded-lg mb-2">Verify</button>
+        <button onClick={() => onOptionSelect('issue')} className="py-4 px-8 bg-green-500 text-white rounded-lg mb-2">Issue</button>
+        <button onClick={() => onOptionSelect('generateProof')} className="py-4 px-8 bg-green-500 text-white rounded-lg mb-2">Generate Proof</button>
+        <button onClick={() => onOptionSelect('verify')} className="py-4 px-8 bg-green-500 text-white rounded-lg mb-2">Verify</button>
       </div>
     </div>
   );
@@ -32,7 +33,7 @@ function App() {
       case 'issue':
         return <SignMessage />;
       case 'generateProof':
-        return <SignMessage />;
+        return <GenerateProof />;
       case 'verify':
         return <VerifyMessage />;
       default:
@@ -56,10 +57,6 @@ function App() {
             Return Home
         </button>
       )}
-    <button>
-
-    </button>
-    
     </div>
   )
   // return (

--- a/vcflow/src/App.js
+++ b/vcflow/src/App.js
@@ -1,48 +1,77 @@
 import React, { useState } from 'react';
-import { ethers } from 'ethers';
 import SignMessage from './SignMessage';
 import VerifyMessage from './VerifyMessage';
 //import GenerateVerifiableCred from './GenerateVerifiableCred';
 
 //Roadmap
-//  1. Instead of a message input, upload a JSON-LD file (SignMessage)
-
-const handleFileUpload = async (file) => {
-  console.log(1)
-  const fileReader = new FileReader();
-  console.log(2)
-  fileReader.onload = async (e) => {
-    console.log(3)
-    const data = JSON.parse(e.target.result);
-    console.log(3)
-    const message = Object.values(data)[0];
-    console.log(4)
-    console.log(message);
-  }
-}
-
-
-
-//  2. Go through the flow and generate a VC-style proof (SignMessage)
-//  3. Download the complete JSON-LD signed VC (App.js)
 //  4. Be able to upload the VC into VerifyMessage and get output
 //  5. Implement docloader to check context?
 
-
-//Question - generating the signature
-
-
-function App() {
+function LandingPage({ onOptionSelect }) {
   return (
-    <div className="container mx-auto bg-green-50 rounded-lg shadow-lg border border-green-300 p-8 m-10 flex flex-wrap">
-      <div className="w-full lg:w-1/2">
-        <SignMessage />
-      </div>
-      <div className="w-full lg:w-1/2">
-        <VerifyMessage />
+    <div className="container mx-auto h-screen flex justify-center items-center">
+      <div className="flex flex-col items-center">
+        <button onClick={() => onOptionSelect('issue')} className="py-2 px-4 bg-green-500 text-white rounded-lg mb-2">Issue</button>
+        <button onClick={() => onOptionSelect('generateProof')} className="py-2 px-4 bg-green-500 text-white rounded-lg mb-2">Generate Proof</button>
+        <button onClick={() => onOptionSelect('verify')} className="py-2 px-4 bg-green-500 text-white rounded-lg mb-2">Verify</button>
       </div>
     </div>
   );
+}
+
+
+function App() {
+  const [selectedOption, setSelectedOption] = useState(null);
+
+  function handleOptionSelect(option) {
+    setSelectedOption(option);
+  }
+
+  function renderPage() {
+    switch (selectedOption) {
+      case 'issue':
+        return <SignMessage />;
+      case 'generateProof':
+        return <SignMessage />;
+      case 'verify':
+        return <VerifyMessage />;
+      default:
+        return (
+          <div>
+            <h1 className="text-3xl font-bold text-green-500 text-center mb-6">
+              ZKVC - Own Your Identity
+            </h1>
+          <LandingPage onOptionSelect={handleOptionSelect} />
+          </div>
+          );
+    }
+  }
+  return(
+    <div className="container mx-auto">
+      {renderPage()}
+      {selectedOption && (
+        <button 
+          className='py-2 px-4 bg-green-500 text-white rounded-lg absolute bottom-0 left-0 mb-6 ml-6'
+          onClick={() => setSelectedOption(null)}>
+            Return Home
+        </button>
+      )}
+    <button>
+
+    </button>
+    
+    </div>
+  )
+  // return (
+  //   <div className="container mx-auto bg-green-50 rounded-lg shadow-lg border border-green-300 p-8 m-10 flex flex-wrap">
+  //     <div className="w-full lg:w-1/2">
+  //       <SignMessage />
+  //     </div>
+  //     <div className="w-full lg:w-1/2">
+  //       <VerifyMessage />
+  //     </div>
+  //   </div>
+  // );
 }
 
 export default App;

--- a/vcflow/src/GenerateProof.js
+++ b/vcflow/src/GenerateProof.js
@@ -1,0 +1,12 @@
+export default function GenerateProof() {
+
+return (
+      <div className="credit-card w-full shadow-lg mx-auto rounded-xl bg-white">
+        <main className="mt-4 p-4">
+          <h1 className="text-xl font-semibold text-gray-700 text-center">
+            Generate Zero Knowledge Proof
+          </h1>
+        </main>
+      </div>
+  );
+}

--- a/vcflow/src/SignMessage.js
+++ b/vcflow/src/SignMessage.js
@@ -30,12 +30,18 @@ export default function SignMessage() {
 
     const handleSign = async (e) => {
         e.preventDefault();
-        const data = new FormData(e.target);
-        const sig = await signMessage({
-            message: data.get("message")
-        });
-        if (sig) {
+        const fileInput = document.getElementById("fileInput");
+        const file = fileInput.files[0];
+        const reader = new FileReader();
+        reader.readAsText(file);
+        reader.onload = async (e) => {
+          const message = e.target.result;                
+          console.log("The message: ", message);
+          const sig = await signMessage({ message });
+          //console.log(sig)
+          if (sig) {
             setSignatures([...signatures, sig])
+          }
         }
     };
 
@@ -48,12 +54,15 @@ export default function SignMessage() {
             </h1>
             <div className="">
               <div className="my-3">
-                <textarea
+                <label htmlFor="fileInput" className="text-m font-semibold text-gray-700">
+                  Select a JSON file to sign
+                </label>
+                <input
                   required
-                  type="text"
-                  name="message"
-                  className="textarea w-full h-24 textarea-bordered focus:ring focus:outline-none"
-                  placeholder="Message"
+                  type="file"
+                  id="fileInput"
+                  accept=".json"
+                  className="w-full h-10"
                 />
               </div>
             </div>
@@ -61,8 +70,7 @@ export default function SignMessage() {
           <footer className="p-4">
             <button
               type="submit"
-              className="btn btn-primary submit-button focus:ring focus:outline-none w-full"
-            >
+              className="btn btn-primary submit-button focus:ring focus:outline-none w-full">
               Sign message
             </button>
           </footer>
@@ -81,6 +89,23 @@ export default function SignMessage() {
                 className="textarea w-full h-24 textarea-bordered focus:ring focus:outline-none"
                 placeholder="Generated signature"
                 value={signatures[signatures.length - 1].signature}
+              />
+              <p>W3C proof format: </p>
+              <textarea
+                type="text"
+                readOnly
+                ref={resultBox}
+                className="textarea w-full h-24 textarea-bordered focus:ring focus:outline-none"
+                placeholder="W3C Proof"
+                value={`
+                "proof": {
+                    "type": "EcdsaSecp256k1RecoverySignature2020",
+                    "created": "${new Date().toISOString()}",
+                    "proofPurpose": "assertionMethod",
+                    "verificationMethod": "add issuer did here",
+                    "jws": "${signatures[signatures.length - 1].signature}"
+                  }`
+                }
               />
             </div>
           </div>

--- a/vcflow/src/SignMessage.js
+++ b/vcflow/src/SignMessage.js
@@ -1,9 +1,10 @@
 import { useState, useRef } from "react";
 const ethers = require("ethers")
 
+// async function that signs the message and returns the signers information for further use 
 const signMessage = async ({ message }) => {
     try {
-        console.log({message});
+        console.log({message}); //testing purposes remove for prod
         if (!window.ethereum) {
             throw new Error("Metamask cannot be found");
         }
@@ -24,29 +25,57 @@ const signMessage = async ({ message }) => {
     }
 };
 
+// exportable signing function for the main App.js 
 export default function SignMessage() {
+    // react hook that ties to the textarea elements for the signature and the proof
     const resultBox = useRef();
+    // state that stores the signature information 
     const [signatures, setSignatures] = useState([]);
 
+    // async function that handles submission and signing
     const handleSign = async (e) => {
         e.preventDefault();
+        // get the file contents
         const fileInput = document.getElementById("fileInput");
         const file = fileInput.files[0];
+        // this reads the actual file
         const reader = new FileReader();
         reader.readAsText(file);
         reader.onload = async (e) => {
+          // save contents of the file
+          /**
+           * @todo THIS SEEMS TO SAVE THE RESULT WITH THE SPACING FORMATTING...SHOULD WE JUST HAVE IT SIGN THE RAW STRING WITH NO SPACING?
+           */
           const message = e.target.result;                
-          console.log("The message: ", message);
+          console.log("The message: ", message); // testing remove for prod
           const sig = await signMessage({ message });
-          //console.log(sig)
           if (sig) {
+            const signedMessage = {
+              ...JSON.parse(message),
+              proof: {
+                type: "EcdsaSecp256k1RecoverySignature2020",
+                created: new Date().toISOString(),
+                proofPurpose: "assertionMethod",
+                verificationMethod: sig.address,
+                jws: sig.signature,
+              },
+            };
+            const signedMessageJSON = JSON.stringify(signedMessage, null, 2);
+            const blob = new Blob([signedMessageJSON], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.href = url;
+            link.download = "signed.json";
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link)
             setSignatures([...signatures, sig])
           }
         }
     };
 
     return (
-      <form className="m-4" onSubmit={handleSign}>
+      <form className="m-4" onSubmit={handleSign}>  
         <div className="credit-card w-full shadow-lg mx-auto rounded-xl bg-white">
           <main className="mt-4 p-4">
             <h1 className="text-xl font-semibold text-gray-700 text-center">
@@ -78,7 +107,7 @@ export default function SignMessage() {
           <div className="p-2" key={signatures[signatures.length - 1].signature}>
             <div className="my-3">
               <p>
-                Message: {signatures[signatures.length - 1].message}
+                {/* Message: {signatures[signatures.length - 1].message}  */}
               </p>
               <p>Signer: {signatures[signatures.length - 1].address}</p>
               <p>Signature: </p>
@@ -102,15 +131,34 @@ export default function SignMessage() {
                     "type": "EcdsaSecp256k1RecoverySignature2020",
                     "created": "${new Date().toISOString()}",
                     "proofPurpose": "assertionMethod",
-                    "verificationMethod": "add issuer did here",
+                    "verificationMethod": "${signatures[signatures.length - 1].address}",
                     "jws": "${signatures[signatures.length - 1].signature}"
                   }`
                 }
               />
+              <a
+                href={`data:text/json;charset=utf-8,${encodeURIComponent(
+                  JSON.stringify({
+                    proof: {
+                      type: "EcdsaSecp256k1RecoverySignature2020",
+                      created: new Date().toISOString(),
+                      proofPurpose: "assertionMethod",
+                      verificationMethod:
+                        signatures[signatures.length - 1].address,
+                      jws: signatures[signatures.length - 1].signature,
+                    },
+                  })
+                )}`}
+              download="signed_message.json"
+            >
+              <button className="btn btn-primary submit-button focus:ring focus:outline-none w-full mt-3">
+                Download JSON
+              </button>
+            </a>
             </div>
           </div>
         }
         </div>
       </form>
     );
-    }
+  }

--- a/vcflow/src/SignMessage.js
+++ b/vcflow/src/SignMessage.js
@@ -46,8 +46,9 @@ export default function SignMessage() {
           /**
            * @todo THIS SEEMS TO SAVE THE RESULT WITH THE SPACING FORMATTING...SHOULD WE JUST HAVE IT SIGN THE RAW STRING WITH NO SPACING?
            */
-          const message = e.target.result;                
-          console.log("The message: ", message); // testing remove for prod
+          const message = JSON.stringify(JSON.parse(e.target.result), 0);
+          console.log(typeof message)               
+          console.log(message); // testing remove for prod
           const sig = await signMessage({ message });
           if (sig) {
             const signedMessage = {

--- a/vcflow/src/VerifyMessage.js
+++ b/vcflow/src/VerifyMessage.js
@@ -25,7 +25,7 @@ export default function VerifyMessage() {
       const file = data.get("signedvc");
       const fileContent = await file.text();
       const json = JSON.parse(fileContent);
-      const m = JSON.stringify(json, null, 2).split('"proof":')[0];
+      const m = JSON.stringify(json, null).split(',"proof":')[0] + '}';
       console.log(m);
       const sig = json.proof.jws;
       const addr = json.proof.verificationMethod

--- a/vcflow/src/VerifyMessage.js
+++ b/vcflow/src/VerifyMessage.js
@@ -29,11 +29,6 @@ export default function VerifyMessage() {
       console.log(m);
       const sig = json.proof.jws;
       const addr = json.proof.verificationMethod
-      // const fileReader = new FileReader();
-      // fileReader.readAsText(file);
-      // fileReader.onload = async () => {
-      //   const json = JSON.parse(fileReader.result);
-      // }
       
       const isValid = await verifyMessage({
         message: m,

--- a/vcflow/src/VerifyMessage.js
+++ b/vcflow/src/VerifyMessage.js
@@ -22,10 +22,23 @@ export default function VerifyMessage() {
     const handleVerification = async (e) => {
       e.preventDefault();
       const data = new FormData(e.target);
+      const file = data.get("signedvc");
+      const fileContent = await file.text();
+      const json = JSON.parse(fileContent);
+      const m = JSON.stringify(json, null, 2).split('"proof":')[0];
+      console.log(m);
+      const sig = json.proof.jws;
+      const addr = json.proof.verificationMethod
+      // const fileReader = new FileReader();
+      // fileReader.readAsText(file);
+      // fileReader.onload = async () => {
+      //   const json = JSON.parse(fileReader.result);
+      // }
+      
       const isValid = await verifyMessage({
-        message: data.get("message"),
-        address: data.get("address"),
-        signature: data.get("signature")
+        message: m,
+        address: addr,
+        signature: sig
       });
   
       if (isValid) {
@@ -46,15 +59,20 @@ return (
           </h1>
           <div className="">
             <div className="my-3">
-              <textarea
+              <input  
+                required
+                type="file"
+                name="signedvc"
+                className="input input-bordered focus:ring focus:outline-none"/>
+              {/* <textarea
                 required
                 type="text"
                 name="message"
                 className="textarea w-full h-24 textarea-bordered focus:ring focus:outline-none"
                 placeholder="Message"
-              />
+              /> */}
             </div>
-            <div className="my-3">
+            {/* <div className="my-3">
               <textarea
                 required
                 type="text"
@@ -71,7 +89,7 @@ return (
                 className="textarea w-full input input-bordered focus:ring focus:outline-none"
                 placeholder="Signer address"
               />
-            </div>
+            </div> */}
           </div>
         </main>
         <footer className="p-4">


### PR DESCRIPTION
Completed the roadmap for the initial POC. Signing a message and Verifying a message are now feature complete according to the POC standards. Additional issues have been opened for feature enhancements 


## Issues

1. Instead of a message input, upload a JSON-LD file (SignMessage)
2. Go through the flow and generate a VC-style proof (SignMessage)
3. Download the complete JSON-LD signed VC (App.js)
4. Be able to upload the VC into VerifyMessage and get correct output

## Solutions

1. Added file handling to `SignMessage` that appends a manual proof portion. After signing, this manually downloads a JSON file
2. A w3c style proof is added manually. However, the `jws` field is just the signature and has not been formatted in accordance to the standard. A separate issue has been opened for this
3. There is auto-download after signing and a manual button to download
4. After some string manipulation - `SignMessage` signs a stringifyed version of the JSON without any spaces and `VerifyMessage` signs the same string with a `}` appended to match the final closing bracket. Error handling will be needed when we move to MVP 